### PR TITLE
PHP7 Support for deprecated style constructors

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -29,7 +29,7 @@ class Instagram {
     * @param $IGDataPath
     *  Default folder to store data, you can change it.
     */
-  public function Instagram($username, $password, $debug = false, $IGDataPath = null)
+  public function __construct($username, $password, $debug = false, $IGDataPath = null)
   {
     $this->username = $username;
     $this->password = $password;

--- a/src/InstagramRegistration.php
+++ b/src/InstagramRegistration.php
@@ -12,7 +12,7 @@ class InstagramRegistration
   protected $username;
   protected $uuid;
 
-  public function InstagramRegistration($debug = false, $IGDataPath = null)
+  public function __construct($debug = false, $IGDataPath = null)
   {
     $this->debug = $debug;
     $this->uuid = $this->generateUUID(true);


### PR DESCRIPTION
Fix for "Methods with the same name as their class will not be constructors in a future version of PHP." error.