### PR TITLE
Fix setUser() -> isLoggedIn / Add proxy support for InstagramRegistration / Fix proxy variable declarations

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -74,6 +74,8 @@ class Instagram
           $this->username_id = $this->settings->get('username_id');
           $this->rank_token = $this->username_id.'_'.$this->uuid;
           $this->token = $this->settings->get('token');
+      }else{
+          $this->isLoggedIn = false;
       }
   }
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -17,6 +17,8 @@ class Instagram
   public $IGDataPath;          // Data storage path
   public $http;
     public $settings;
+    public $proxy = null;        // Proxy
+    public $proxy_auth = null;   // Proxy Auth
 
   /**
    * Default class constructor.

--- a/src/InstagramRegistration.php
+++ b/src/InstagramRegistration.php
@@ -106,7 +106,7 @@ class InstagramRegistration
           'username'           => $username,
           'first_name'         => '',
           'guid'               => $this->uuid,
-          'device_id'          => 'android-'.str_split(md5(mt_rand(1000, 9999)), 17)[mt_rand(0, 1)],
+          'device_id'          => $this->generateDeviceId(md5($username.$password)),
           'email'              => $email,
           'force_sign_up_code' => '',
           'qs_stamp'           => '',
@@ -126,6 +126,11 @@ class InstagramRegistration
 
       return $result;
   }
+
+    public function generateDeviceId($seed)
+    {
+        return 'android-'.substr(md5($seed), 16);
+    }
 
     public function generateSignature($data)
     {

--- a/src/InstagramRegistration.php
+++ b/src/InstagramRegistration.php
@@ -9,6 +9,8 @@ class InstagramRegistration
     protected $username;
     protected $uuid;
     protected $userAgent;
+    protected $proxy = null;        // Proxy
+    protected $proxy_auth = null;   // Proxy Auth
 
     public function __construct($debug = false, $IGDataPath = null)
     {

--- a/src/InstagramRegistration.php
+++ b/src/InstagramRegistration.php
@@ -23,6 +23,50 @@ class InstagramRegistration
         $this->userAgent = 'Instagram '.Constants::VERSION.' Android (18/4.3; 320dpi; 720x1280; Xiaomi; HM 1SW; armani; qcom; en_US)';
     }
 
+    /**
+     * Set the proxy.
+     *
+     * @param string $proxy
+     *   Full proxy string. Ex: user:pass@192.168.0.0:8080
+     *   Use $proxy = "" to clear proxy
+     * @param integer $port
+     *   Port of proxy
+     * @param string $username
+     *   Username for proxy
+     * @param string $password
+     *   Password for proxy
+     * @throws InstagramException
+     *
+     */
+    public function setProxy($proxy, $port = null, $username = null, $password = null)
+    {
+        if($proxy == ""){
+            $this->proxy = "";
+            return;
+        }
+
+        $proxy = parse_url($proxy);
+
+        if(!is_null($port) && is_int($port)) {
+            $proxy["port"] = $port;
+        }
+
+        if (!is_null($username) && !is_null($password)) {
+            $proxy["user"] = $username;
+            $proxy["pass"] = $password;
+        }
+
+        if (!empty($proxy["host"]) && isset($proxy["port"]) && is_int($proxy["port"])) {
+            $this->proxy = $proxy["host"].":".$proxy["port"];
+        } else {
+            throw new InstagramException('Proxy host error. Please check ip address and port of proxy.');
+        }
+
+        if (isset($proxy["user"]) && isset($proxy["pass"])) {
+            $this->proxy_auth = $proxy["user"].":".$proxy["pass"];
+        }
+    }
+    
   /**
    * Checks if the username is already taken (exists).
    *
@@ -122,6 +166,13 @@ class InstagramRegistration
         if ($post) {
             curl_setopt($ch, CURLOPT_POST, true);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+        }
+
+        if ($this->proxy) {
+            curl_setopt($ch, CURLOPT_PROXY, $this->proxy);
+            if ($this->proxy_auth) {
+                curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->proxy_auth);
+            }
         }
 
         $resp = curl_exec($ch);


### PR DESCRIPTION
**FIRST COMMIT:**
When you use `setUser()` to switch users  and the previous user was logged in, but the current user is not,  `$this->isLoggedIn` should be false.

Which lets this work correctly:
```
$i->setUser($user,$pass);    // switch user
if(!$i->isLoggedIn){         // check if already logged in
    $i->login();             // if not, log in
}
```
**SECOND COMMIT**
Adds `setProxy()` function for InstagramRegistration

**THIRD COMMIT**
I forgot to declare the variables for the proxy functions
`$proxy` & `$proxy_auth`