### PR TITLE
update Response class with setFullResponse() and getFullResponse(). update mediaInfoResponse() with setFullResponse()

### DIFF
--- a/src/http/Response/MediaInfoResponse.php
+++ b/src/http/Response/MediaInfoResponse.php
@@ -30,5 +30,6 @@ class MediaInfoResponse extends Response
             $this->setMessage($response['message']);
         }
         $this->setStatus($response['status']);
+        $this->setFullResponse($response);
     }
 }

--- a/src/http/Response/Response.php
+++ b/src/http/Response/Response.php
@@ -9,6 +9,7 @@ class Response
 
     protected $status;
     protected $message;
+    protected $fullResponse;
 
     public function setStatus($status)
     {
@@ -30,6 +31,16 @@ class Response
         return $this->message;
     }
 
+    public function setFullResponse($response)
+    {
+        $this->fullResponse = $response;
+    }
+
+    public function getFullResponse()
+    {
+        return $this->fullResponse;
+    }
+    
     public function isOk()
     {
         return $this->getStatus() == self::STATUS_OK;


### PR DESCRIPTION
In response to the other pull request...

May be better to update response class with getter/setter for the full response so it can be used in other responses later on if needed. Instead of a one-off function for mediainforesponse()