### PR TITLE
add missing init for original_height

### DIFF
--- a/src/http/Response/Objects/Item.php
+++ b/src/http/Response/Objects/Item.php
@@ -59,6 +59,7 @@ class Item
         }
         $this->image_versions2 = $images;
         $this->original_width = $item['original_width'];
+        $this->original_height = $item['original_height'];
         if (isset($item['view_count'])) {
             $this->view_count = $item['view_count'];
         }


### PR DESCRIPTION
`original_width` was set for Item but `original_height` was always null because it forgotten to set int `__construct` of `Item`.