### PR TITLE
Fixing broken code added in #579

### DIFF
--- a/src/Utils/Settings.php
+++ b/src/Utils/Settings.php
@@ -51,9 +51,6 @@ class Settings
         if (file_exists($this->path)) {
             unlink($this->path);
         }
-        if (!is_writable($this->path)) {
-            throw new InstagramException("path : \"" . $this->path . "\" not writable. ");
-        }
         $fp = fopen($this->path, 'wb');
         fseek($fp, 0);
         foreach ($this->sets as $key => $value) {


### PR DESCRIPTION
#579 introduced a strange bit of code that pretty much breaks the library in all circumstances. It asks if the data **file** is writable (not the data **path**), despite having just deleted that file in the line above, and disregarding the fact that new installs won't have that file there anyway.

I'm guessing what the submitter was trying to do was check if the `/data` directory is writable, but that requires a small rewrite of the parameters for the constructor of this class. This PR reverts the change to make the library usable again.