### PR TITLE
Add reels media feed

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -1283,6 +1283,30 @@ class Instagram
     }
 
     /**
+     * Get multiple users' story reels.
+     *
+     * @param array $userList List of User IDs
+     *
+     * @return ReelsMediaResponse
+     */
+    public function getReelsMediaFeed($userList)
+    {
+        if (!is_array($userList)) {
+            $userList = [$userList];
+        }
+
+        $userIDs = [];
+        foreach ($userList as $userId) {
+            $userIDs[] = "$userId";
+        }
+
+        return $this->request('feed/reels_media/')
+        ->setSignedPost(true)
+        ->addPost('user_ids', $userIDs)
+        ->getResponse(new ReelsMediaResponse());
+    }
+
+    /**
      * Get user feed.
      *
      * @param string $usernameId   Username id

--- a/src/http/Response/ReelsMediaResponse.php
+++ b/src/http/Response/ReelsMediaResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace InstagramAPI;
+
+class ReelsMediaResponse extends Response
+{
+    /**
+     * @var Reel[]
+     */
+    public $reels_media;
+
+    public $reels;
+}


### PR DESCRIPTION
As mentioned in #806, a response with an associative array.

New endpoint:
- ``feed/reels_media/``

Usage:
```php
$api = new \InstagramAPI\Instagram(false);
// ....
$userList = array('25025320', '189393625');
$result = $api->getReelsMediaFeed($userList);
var_dump($result->reels);

```