### PR TITLE
fix `pk` access path, Fix #820

### DIFF
--- a/src/InstagramRegistration.php
+++ b/src/InstagramRegistration.php
@@ -170,7 +170,11 @@ class InstagramRegistration
     {
         $fetch = $this->request('si/fetch_headers/', null, true);
         $header = $fetch[0];
-        $response = new ChallengeResponse($fetch[1]);
+
+        $mapper = new \JsonMapper();
+        $mapper->bStrictNullTypes = false;
+        $mapper->bEnforceMapType = false;
+        $response = $mapper->map($fetch[1], new ChallengeResponse());
 
         if (!isset($header) || (!$response->isOk())) {
             throw new InstagramException("Couldn't get challenge, check your connection");

--- a/src/http/Response/AccountCreationResponse.php
+++ b/src/http/Response/AccountCreationResponse.php
@@ -32,7 +32,7 @@ class AccountCreationResponse extends Response
             $this->feedback_message = $response['feedback_message'];
         } else {
             $this->account_created = $response['account_created'];
-            $this->pk = $response['pk'];
+            $this->pk = $response['created_user']['pk'];
         }
     }
 

--- a/src/http/Response/ChallengeResponse.php
+++ b/src/http/Response/ChallengeResponse.php
@@ -6,8 +6,4 @@ class ChallengeResponse extends Response
 {
     public $status;
 
-    public function __construct($response)
-    {
-        $this->status = $response['status'];
-    }
 }


### PR DESCRIPTION
Gets rid of this message after a successful registration

```
Your account was successfully created! :)
PHP Notice:  Undefined index: pk in /home/danleyb2/PhpstormProjects/instagramapi-test/vendor/mgp25/instagram-php/src/http/Response/AccountCreationResponse.php on line 35

```

Fixes Issue #820  which is just a warning initializing ChallengeResponse for JsonMapper (there is no `response` parameter passed)
