### PR TITLE
endpoint fix

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -125,7 +125,7 @@ class Instagram
         if (!$this->isLoggedIn || $force) {
             $this->syncFeatures(true);
 
-            $response = $this->request('si/fetch_headers')
+            $response = $this->request('si/fetch_headers/')
             ->requireLogin(true)
             ->addParams('challenge_type', 'signup')
             ->addParams('guid', SignatureUtils::generateUUID(false))


### PR DESCRIPTION
Instagram returns redirect from endpoint 'si/fetch_headers' to 'si/fetch_headers/'
check your logs while login()