### PR TITLE
Allow pagination for getUserTags function

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -1157,8 +1157,8 @@ class Instagram
         return $this->request("usertags/$usernameId/feed/")
         ->addParams('rank_token', $this->rank_token)
         ->addParams('ranked_content', 'true')
-		->addParams('max_id', (!is_null($maxid) ? $maxid : ''))
-		->addParams('min_timestamp', (!is_null($minTimestamp) ? $minTimestamp : ''))
+	->addParams('max_id', (!is_null($maxid) ? $maxid : ''))
+	->addParams('min_timestamp', (!is_null($minTimestamp) ? $minTimestamp : ''))
         ->getResponse(new UsertagsResponse());
     }
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -1152,11 +1152,13 @@ class Instagram
      *
      * @return UsertagsResponse user tags data
      */
-    public function getUserTags($usernameId)
+    public function getUserTags($usernameId, $maxid = null, $minTimestamp = null)
     {
         return $this->request("usertags/$usernameId/feed/")
         ->addParams('rank_token', $this->rank_token)
         ->addParams('ranked_content', 'true')
+		->addParams('max_id', (!is_null($maxid) ? $maxid : ''))
+		->addParams('min_timestamp', (!is_null($minTimestamp) ? $minTimestamp : ''))
         ->getResponse(new UsertagsResponse());
     }
 

--- a/src/http/HttpInterface.php
+++ b/src/http/HttpInterface.php
@@ -104,7 +104,7 @@ class HttpInterface
 
             return $this->request($endpoint, $post, $login, false, $assoc);
         } else {
-            return [$header, json_decode($body, $assoc)];
+            return [$header, json_decode($body, $assoc, 512, JSON_BIGINT_AS_STRING)];
         }
     }
 


### PR DESCRIPTION
this basically just adds the parameters, but on top of that, enables JSON_BIGINT_AS_STRING in the json_decode function.

The json_decode change is required since the returned next_max_id for the getusertags request is a very long numerical string - without JSON_BIGINT_AS_STRING, the code will convert the ID to int and turn it into an exponential number due to 32bit limitations in ints.