### PR TITLE
Maintaining image quality at 100%

### DIFF
--- a/src/Utils/AdaptImage.php
+++ b/src/Utils/AdaptImage.php
@@ -105,7 +105,7 @@ class AdaptImage
                 imagecopyresized($im, $this->images, $this->x, 0, 0, 0, $this->newWidth, 799, $this->width, $this->height);
             }
             ob_start();
-            imagejpeg($im);
+            imagejpeg($im, null, 100);
             $data = ob_get_contents();
             ob_end_clean();
 


### PR DESCRIPTION
In some tests I did I could see that the image quality was getting very low.
I then verified that the imagejpeg () function was not set to the maximum quality, when it is set to no value, the default value is 75% of quality.
I changed the function to leave the value at 100%. The gain in quality is visible and makes a big difference in the post.
