### PR TITLE
Improving settings adapter

### DIFF
--- a/examples/usingMemcachedSettingsAdapter.php
+++ b/examples/usingMemcachedSettingsAdapter.php
@@ -1,0 +1,31 @@
+<?php
+
+include __DIR__.'/../vendor/autoload.php';
+
+
+// Example using Memcached for storing settings and cookies
+$i = new \InstagramAPI\Instagram(true, false, [
+    'type'  => 'custom',
+    'class' => \InstagramAPI\SettingsAdapter\Memcached::class,
+    'persistent_id' => 'instagram',
+    'memcache_options' => [
+        Memcached::OPT_PREFIX_KEY => 'settings_'
+    ],
+    'servers' => [[
+        'host' => 'localhost',
+        'port' => 11211,
+        'weight' => 0
+    ], [
+        'host' => 'other.host.com',
+        'port' => 11211,
+        'weight' => 1
+    ]]
+]);
+$i->setUser($username, $password);
+
+try {
+    $i->login();
+} catch (Exception $e) {
+    echo 'something went wrong '.$e->getMessage()."\n";
+    exit(0);
+}

--- a/src/InstagramRegistration.php
+++ b/src/InstagramRegistration.php
@@ -241,6 +241,9 @@ class InstagramRegistration
         if ($this->settingsAdapter['type'] == 'mysql') {
             $newCookies = file_get_contents($cookieJarFile);
             $this->settings->set('cookies', $newCookies);
+        } elseif ($this->settings->setting instanceof SettingsAdapter\SettingsInterface) {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->settings->set('cookies', $newCookies);
         }
 
         if ($this->debug) {

--- a/src/Utils/SettingsAdapter.php
+++ b/src/Utils/SettingsAdapter.php
@@ -15,11 +15,11 @@ class SettingsAdapter
                 'db_name::',
             ];
             $options = getopt('', $longOpts);
-                
+
             if (!$options) {
                 $options = [];
             }
-                
+
             $env_username = getenv('DB_USERNAME');
             $env_password = getenv('DB_PASSWORD');
             $env_host = getenv('DB_HOST');
@@ -37,11 +37,11 @@ class SettingsAdapter
                 'settings_path::',
             ];
             $options = getopt('', $longOpts);
-                
+
             if (!$options) {
                 $options = [];
             }
-                
+
             $env_settings_path = getenv('SETTINGS_PATH');
             if (array_key_exists('path', $config)) {
                 $settings_path = $config['path'];
@@ -61,7 +61,7 @@ class SettingsAdapter
 
             $customClass = $config['class'];
             /** @var SettingsAdapter\SettingsInterface $settings */
-            $settings    = new $customClass($username, $config);
+            $settings = new $customClass($username, $config);
 
             $this->setting = $settings;
             break;

--- a/src/Utils/SettingsAdapter.php
+++ b/src/Utils/SettingsAdapter.php
@@ -54,6 +54,17 @@ class SettingsAdapter
             }
             $this->setting = new SettingsFile($username, $settings_path);
             break;
+        case 'custom':
+            if (!isset($config['class']) || !class_exists($config['class']) || !in_array(SettingsAdapter\SettingsInterface::class, class_implements($config['class']))) {
+                throw new InstagramException('Unknown custom settings class specified', ErrorCode::INTERNAL_SETTINGS_ERROR);
+            }
+
+            $customClass = $config['class'];
+            /** @var SettingsAdapter\SettingsInterface $settings */
+            $settings    = new $customClass($username, $config);
+
+            $this->setting = $settings;
+            break;
         default:
             throw new InstagramException('Unrecognized settings type', ErrorCode::INTERNAL_SETTINGS_ERROR);
         }

--- a/src/Utils/SettingsAdapter/Memcached.php
+++ b/src/Utils/SettingsAdapter/Memcached.php
@@ -3,7 +3,7 @@
 namespace InstagramAPI\SettingsAdapter;
 
 /**
- * Class Memcached
+ * Class Memcached.
  *
  * @author ilyk <ilyk@ilyk.im>
  */
@@ -22,7 +22,7 @@ class Memcached implements SettingsInterface
      */
     public function __construct($instagramUsername, $config)
     {
-        $this->memcached = $memcached= new \Memcached(isset($config['persistent_id']) ? $config['persistent_id'] : 'instagram');
+        $this->memcached = $memcached = new \Memcached(isset($config['persistent_id']) ? $config['persistent_id'] : 'instagram');
 
         if (isset($config['init_callback']) && is_callable($config['init_callback'])) {
             $config['init_callback']($memcached);

--- a/src/Utils/SettingsAdapter/Memcached.php
+++ b/src/Utils/SettingsAdapter/Memcached.php
@@ -4,7 +4,6 @@ namespace InstagramAPI\SettingsAdapter;
 
 /**
  * Class Memcached
- * @package InstagramAPI\SettingsAdapter
  *
  * @author ilyk <ilyk@ilyk.im>
  */
@@ -21,7 +20,8 @@ class Memcached implements SettingsInterface
      * @param string $instagramUsername
      * @param array  $config
      */
-    public function __construct($instagramUsername, $config) {
+    public function __construct($instagramUsername, $config)
+    {
         $this->memcached = $memcached= new \Memcached(isset($config['persistent_id']) ? $config['persistent_id'] : 'instagram');
 
         if (isset($config['init_callback']) && is_callable($config['init_callback'])) {
@@ -29,7 +29,7 @@ class Memcached implements SettingsInterface
         }
 
         if (isset($config['memcache_options'])) {
-            $memcached->setOptions((array)$config['memcache_options']);
+            $memcached->setOptions((array) $config['memcache_options']);
         }
 
         if (isset($config['servers'])) {
@@ -77,6 +77,5 @@ class Memcached implements SettingsInterface
      */
     public function Save()
     {
-        return;
     }
 }

--- a/src/Utils/SettingsAdapter/Memcached.php
+++ b/src/Utils/SettingsAdapter/Memcached.php
@@ -61,6 +61,7 @@ class Memcached implements SettingsInterface
     public function get($key, $default = null)
     {
         $result = $this->memcached->get($key);
+
         return \Memcached::RES_NOTFOUND === $this->memcached->getResultCode() ? $default : $result;
     }
 

--- a/src/Utils/SettingsAdapter/Memcached.php
+++ b/src/Utils/SettingsAdapter/Memcached.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace InstagramAPI\SettingsAdapter;
+
+/**
+ * Class Memcached
+ * @package InstagramAPI\SettingsAdapter
+ *
+ * @author ilyk <ilyk@ilyk.im>
+ */
+class Memcached implements SettingsInterface
+{
+    /**
+     * @var \Memcached
+     */
+    protected $memcached;
+
+    /**
+     * Memcached constructor.
+     *
+     * @param string $instagramUsername
+     * @param array  $config
+     */
+    public function __construct($instagramUsername, $config) {
+        $this->memcached = $memcached= new \Memcached(isset($config['persistent_id']) ? $config['persistent_id'] : 'instagram');
+
+        if (isset($config['init_callback']) && is_callable($config['init_callback'])) {
+            $config['init_callback']($memcached);
+        }
+
+        if (isset($config['memcache_options'])) {
+            $memcached->setOptions((array)$config['memcache_options']);
+        }
+
+        if (isset($config['servers'])) {
+            $memcached->addServers($config['servers']);
+        } elseif (isset($config['server'])) {
+            $memcached->addServer($config['server']['host'], isset($config['server']['port']) ? $config['server']['port'] : 11211, isset($config['server']['weight']) ? $config['server']['weight'] : 0);
+        } else {
+            $memcached->addServer('localhost', 11211);
+        }
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return void
+     */
+    public function set($key, $value)
+    {
+        $this->memcached->set($key, $value);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        $result = $this->memcached->get($key);
+        return \Memcached::RES_NOTFOUND === $this->memcached->getResultCode() ? $default : $result;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLogged()
+    {
+        return $this->get('id') !== null && $this->get('username_id') !== null && $this->get('token') !== null;
+    }
+
+    /**
+     * @return void
+     */
+    public function Save()
+    {
+        return;
+    }
+}

--- a/src/Utils/SettingsAdapter/SettingsInterface.php
+++ b/src/Utils/SettingsAdapter/SettingsInterface.php
@@ -4,7 +4,6 @@ namespace InstagramAPI\SettingsAdapter;
 
 /**
  * Interface SettingsInterface
- * @package InstagramAPI\SettingsAdapter
  *
  * @author ilyk <ilyk@ilyk.im>
  */
@@ -14,13 +13,13 @@ interface SettingsInterface
      * SettingsInterface constructor.
      *
      * @param string $instagramUsername
-     * @param array $config
+     * @param array  $config
      */
     public function __construct($instagramUsername, $config);
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return void
      */
@@ -28,7 +27,7 @@ interface SettingsInterface
 
     /**
      * @param string $key
-     * @param mixed $default
+     * @param mixed  $default
      *
      * @return mixed
      */

--- a/src/Utils/SettingsAdapter/SettingsInterface.php
+++ b/src/Utils/SettingsAdapter/SettingsInterface.php
@@ -3,7 +3,7 @@
 namespace InstagramAPI\SettingsAdapter;
 
 /**
- * Interface SettingsInterface
+ * Interface SettingsInterface.
  *
  * @author ilyk <ilyk@ilyk.im>
  */

--- a/src/Utils/SettingsAdapter/SettingsInterface.php
+++ b/src/Utils/SettingsAdapter/SettingsInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace InstagramAPI\SettingsAdapter;
+
+/**
+ * Interface SettingsInterface
+ * @package InstagramAPI\SettingsAdapter
+ *
+ * @author ilyk <ilyk@ilyk.im>
+ */
+interface SettingsInterface
+{
+    /**
+     * SettingsInterface constructor.
+     *
+     * @param string $instagramUsername
+     * @param array $config
+     */
+    public function __construct($instagramUsername, $config);
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return void
+     */
+    public function set($key, $value);
+
+    /**
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null);
+
+    /**
+     * @return bool
+     */
+    public function isLogged();
+
+    /**
+     * @return void
+     */
+    public function Save();
+}

--- a/src/http/HttpInterface.php
+++ b/src/http/HttpInterface.php
@@ -40,7 +40,7 @@ class HttpInterface
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_VERBOSE, false);
-        curl_setopt($ch, CURLOPT_ENCODING,  '');
+        curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verifyPeer);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->verifyHost);
         if ($this->parent->settingsAdapter['type'] == 'file') {
@@ -211,7 +211,7 @@ class HttpInterface
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_VERBOSE, false);
-        curl_setopt($ch, CURLOPT_ENCODING,  '');
+        curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verifyPeer);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->verifyHost);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
@@ -328,7 +328,7 @@ class HttpInterface
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_VERBOSE, false);
-        curl_setopt($ch, CURLOPT_ENCODING,  '');
+        curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         if ($this->parent->settingsAdapter['type'] == 'file') {
             curl_setopt($ch, CURLOPT_COOKIEFILE, $this->parent->settings->cookiesPath);
@@ -401,7 +401,7 @@ class HttpInterface
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLOPT_HEADER, true);
             curl_setopt($ch, CURLOPT_VERBOSE, false);
-            curl_setopt($ch, CURLOPT_ENCODING,  '');
+            curl_setopt($ch, CURLOPT_ENCODING, '');
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             if ($this->parent->settingsAdapter['type'] == 'file') {
                 curl_setopt($ch, CURLOPT_COOKIEFILE, $this->parent->settings->cookiesPath);

--- a/src/http/HttpInterface.php
+++ b/src/http/HttpInterface.php
@@ -20,7 +20,6 @@ class HttpInterface
     {
         if (!$this->parent->isLoggedIn && !$login) {
             throw new InstagramException("User is not logged in - login() must be called before making login-enforced requests.\n", ErrorCode::INTERNAL_LOGIN_REQUIRED);
-            return;
         }
 
         $headers = [
@@ -93,6 +92,9 @@ class HttpInterface
         curl_close($ch);
 
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
         }
@@ -257,10 +259,12 @@ class HttpInterface
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
         }
         if (!$upload->isOk()) {
             throw new InstagramException($upload->getMessage());
-            return;
         }
 
         if ($reel_flag) {
@@ -465,6 +469,9 @@ class HttpInterface
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
         }
         $configure = $this->parent->configureVideo($upload_id, $video, $caption, $customPreview);
         //$this->parent->expose();
@@ -579,6 +586,9 @@ class HttpInterface
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
         }
     }
 
@@ -685,6 +695,9 @@ class HttpInterface
 
         curl_close($ch);
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
         }
@@ -795,6 +808,9 @@ class HttpInterface
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
         }
     }
 
@@ -898,7 +914,6 @@ class HttpInterface
 
         if (!$upload->isOk()) {
             throw new InstagramException($upload->getMessage());
-            return;
         }
 
         if ($this->parent->debug) {
@@ -915,6 +930,9 @@ class HttpInterface
 
         curl_close($ch);
         if ($this->parent->settingsAdapter['type'] == 'mysql') {
+            $newCookies = file_get_contents($cookieJarFile);
+            $this->parent->settings->set('cookies', $newCookies);
+        } elseif ($this->parent->settings->setting instanceof SettingsAdapter\SettingsInterface) {
             $newCookies = file_get_contents($cookieJarFile);
             $this->parent->settings->set('cookies', $newCookies);
         }


### PR DESCRIPTION
This pull request adds ability to create your own settings adapters.
The main rules are
1. Implement `InstagramAPI\SettingsAdapter\SettingsInterface` interface
2. Specify *settingsAdapter* array key **type = custom** and **class = className** of needed adapter;

example:
```
$instagram = new \InstagramAPI\Instagram(true, false, [
    'type'  => 'custom',
    'class' => \InstagramAPI\SettingsAdapter\Memcached::class
]);
```
