### PR TITLE
Fixed bugged login exceptions

### DIFF
--- a/src/Exception/LoginException.php
+++ b/src/Exception/LoginException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace InstagramAPI\Exception;
-
-class LoginException extends RequestException
-{
-}


### PR DESCRIPTION
Hello sir! :)

Recent commit 42beba3134ef9ef9c8b40e56406ba46bba2c94c4
added two factor login but broke the login exception system.

This fix reuses the same method of throwing as in Client.php
which makes proper exceptions thrown at login again, such as:

"Uncaught InstagramAPI\Exception\IncorrectPasswordException:
InstagramAPI\Response\LoginResponse: The password you entered is
incorrect. Please try again."