### PR TITLE
login(): Fix and document return value

### DIFF
--- a/examples/twoFactorLogin.php
+++ b/examples/twoFactorLogin.php
@@ -18,7 +18,7 @@ try {
     $ig->setUser($username, $password);
     $loginResponse = $ig->login();
 
-    if ($loginResponse->getTwoFactorRequired()) {
+    if (!is_null($loginResponse) && $loginResponse->getTwoFactorRequired()) {
         $twoFactorIdentifier = $loginResponse->getTwoFactorInfo()->getTwoFactorIdentifier();
 
          // The "STDIN" lets you paste the code via terminal for testing.

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -411,6 +411,7 @@ class Instagram
                     // only save it to settings storage AFTER successful login!
                     $this->token = $response->getFullResponse()[0];
 
+                    // Return server response to tell user they need 2-factor.
                     return $response;
                 } else {
                     // Login failed for some other reason... Throw error.
@@ -421,9 +422,14 @@ class Instagram
             $this->_updateLoginState($response);
 
             $this->_sendLoginFlow(true, $appRefreshInterval);
+
+            // Full (re-)login successfully completed. Return server response.
+            return $response;
         }
 
-        $this->_sendLoginFlow(false, $appRefreshInterval);
+        // Attempt to resume an existing session, or full re-login if necessary.
+        // NOTE: The "return" here gives a LoginResponse in case of re-login.
+        return $this->_sendLoginFlow(false, $appRefreshInterval);
     }
 
     /**
@@ -494,6 +500,9 @@ class Instagram
      *
      * @throws \InvalidArgumentException
      * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\LoginResponse|null A login response if a full (re-)login is needed
+     *                                                   during the login flow attempt, otherwise NULL.
      */
     protected function _sendLoginFlow(
         $justLoggedIn,

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -377,7 +377,8 @@ class Instagram
      * @throws \InvalidArgumentException
      * @throws \InstagramAPI\Exception\InstagramException
      *
-     * @return \InstagramAPI\Response\LoginResponse
+     * @return \InstagramAPI\Response\LoginResponse|null A login response if a full (re-)login happens,
+     *                                                   otherwise NULL if an existing session is resumed.
      */
     public function login(
         $forceLogin = false,
@@ -423,8 +424,6 @@ class Instagram
         }
 
         $this->_sendLoginFlow(false, $appRefreshInterval);
-
-        return $response;
     }
 
     /**


### PR DESCRIPTION
- Reverts 5d8be61e3c8b0e285a6a4ad2222dd879103548e9, since there
  was no way for us to always return a LoginResponse.

- Documents return value properly.