### PR TITLE
Implement comment blocked-words functionality.

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -2484,6 +2484,72 @@ class Instagram
     }
 
     /**
+     * Get account spam filter status.
+     *
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\CommentFilterResponse
+     */
+    public function getCommentFilter()
+    {
+        return $this->request('accounts/get_comment_filter/')
+            ->getResponse(new Response\CommentFilterResponse());
+    }
+
+    /**
+     * Get account spam filter keywords.
+     *
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\CommentFilterResponse
+     */
+    public function getCommentFilterKeywords()
+    {
+        return $this->request('accounts/get_comment_filter_keywords/')
+            ->getResponse(new Response\CommentFilterKeywordsResponse());
+    }
+
+    /**
+     * Set account spam filter status (on/off).
+     *
+     * @param int $config_value 0 or 1, whether spam filter is on
+     *
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\CommentFilterResponse
+     */
+    public function setCommentFilter($config_value)
+    {
+        return $this->request("accounts/set_comment_filter/")
+            ->addPost('_uuid', $this->uuid)
+            ->addPost('_uid', $this->account_id)
+            ->addPost('_csrftoken', $this->token)
+            ->addPost('config_value', $config_value)
+            ->setSignedPost(true)
+            ->getResponse(new Response\CommentFilterSetResponse());
+    }
+
+    /**
+     * Set account spam filter keywords.
+     *
+     * @param string $keywords list of stop-words, separated by comma
+     *
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\CommentFilterResponse
+     */
+    public function setCommentFilterKeywords($keywords)
+    {
+        return $this->request("accounts/set_comment_filter_keywords/")
+            ->addPost('_uuid', $this->uuid)
+            ->addPost('_uid', $this->account_id)
+            ->addPost('_csrftoken', $this->token)
+            ->addPost('keywords', $keywords)
+            ->setSignedPost(true)
+            ->getResponse(new Response\CommentFilterSetResponse());
+    }
+
+    /**
      * Get recent activity.
      *
      * @throws \InstagramAPI\Exception\InstagramException

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -2501,7 +2501,7 @@ class Instagram
      *
      * @throws \InstagramAPI\Exception\InstagramException
      *
-     * @return \InstagramAPI\Response\CommentFilterResponse
+     * @return \InstagramAPI\Response\CommentFilterKeywordsResponse
      */
     public function getCommentFilterKeywords()
     {
@@ -2512,13 +2512,14 @@ class Instagram
     /**
      * Set account spam filter status (on/off).
      *
-     * @param int $config_value 0 or 1, whether spam filter is on
+     * @param int $config_value Whether spam filter is on (0 or 1).
      *
      * @throws \InstagramAPI\Exception\InstagramException
      *
-     * @return \InstagramAPI\Response\CommentFilterResponse
+     * @return \InstagramAPI\Response\CommentFilterSetResponse
      */
-    public function setCommentFilter($config_value)
+    public function setCommentFilter(
+        $config_value)
     {
         return $this->request('accounts/set_comment_filter/')
             ->addPost('_uuid', $this->uuid)
@@ -2532,13 +2533,14 @@ class Instagram
     /**
      * Set account spam filter keywords.
      *
-     * @param string $keywords list of stop-words, separated by comma
+     * @param string $keywords List of blocked words, separated by comma.
      *
      * @throws \InstagramAPI\Exception\InstagramException
      *
-     * @return \InstagramAPI\Response\CommentFilterResponse
+     * @return \InstagramAPI\Response\CommentFilterSetResponse
      */
-    public function setCommentFilterKeywords($keywords)
+    public function setCommentFilterKeywords(
+        $keywords)
     {
         return $this->request('accounts/set_comment_filter_keywords/')
             ->addPost('_uuid', $this->uuid)

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -2520,7 +2520,7 @@ class Instagram
      */
     public function setCommentFilter($config_value)
     {
-        return $this->request("accounts/set_comment_filter/")
+        return $this->request('accounts/set_comment_filter/')
             ->addPost('_uuid', $this->uuid)
             ->addPost('_uid', $this->account_id)
             ->addPost('_csrftoken', $this->token)
@@ -2540,7 +2540,7 @@ class Instagram
      */
     public function setCommentFilterKeywords($keywords)
     {
-        return $this->request("accounts/set_comment_filter_keywords/")
+        return $this->request('accounts/set_comment_filter_keywords/')
             ->addPost('_uuid', $this->uuid)
             ->addPost('_uid', $this->account_id)
             ->addPost('_csrftoken', $this->token)

--- a/src/Response/CommentFilterKeywordsResponse.php
+++ b/src/Response/CommentFilterKeywordsResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace InstagramAPI\Response;
+
+class CommentFilterKeywordsResponse extends \InstagramAPI\Response
+{
+    public $keywords;
+}

--- a/src/Response/CommentFilterResponse.php
+++ b/src/Response/CommentFilterResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace InstagramAPI\Response;
+
+class CommentFilterResponse extends \InstagramAPI\Response
+{
+    public $config_value;
+}

--- a/src/Response/CommentFilterSetResponse.php
+++ b/src/Response/CommentFilterSetResponse.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace InstagramAPI\Response;
+
+class CommentFilterSetResponse extends \InstagramAPI\Response
+{
+}


### PR DESCRIPTION
Instagram has a function, that allows you to hide inappropriate comments. Here is a screenshot of this interface, so you can clearly understand what I'm talking about:

![image](https://cloud.githubusercontent.com/assets/5718556/25578997/f26b7de2-2e9d-11e7-8d16-4a53f647e2c9.png)

However, I didn't find it implemented in this library. This request adds an ability to use this functionality.

New endpoints are:
**accounts/get_comment_filter/
accounts/get_comment_filter_keywords/
accounts/set_comment_filter/
accounts/set_comment_filter_keywords/**

Unfortunately, I didn't manage how I can ignore SSL pinning on Android, so I used my iPhone to sniff requests. But then I checked all requests with decompiled Android v10.9.0 app source code. And they are completely same.

I can provide all the additional information, if needed.

P.S. If you know anything about bypassing SSL pinning on latest app versions,  pls give any point on how to do it 🙏. It'd really save time on comparing iOS version requests with Android.