### PR TITLE
Fixes for multipart requests

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1402,7 +1402,7 @@ class Client
                 'type'     => 'form-data',
                 'name'     => 'photo',
                 'data'     => file_get_contents($shareData['filepath']),
-                'filename' => 'photo',
+                'filename' => 'direct_temp_photo_'.Utils::generateUploadId().'.jpg',
                 'headers'  => [
                     'Content-Type: '.mime_content_type($shareData['filepath']),
                     'Content-Transfer-Encoding: binary',
@@ -1464,8 +1464,7 @@ class Client
             $body .= '--'.$boundary."\r\n";
             $body .= 'Content-Disposition: '.$b['type'].'; name="'.$b['name'].'"';
             if (isset($b['filename'])) {
-                $ext = pathinfo($b['filename'], PATHINFO_EXTENSION);
-                $body .= '; filename="'.'pending_media_'.Utils::generateUploadId().'.'.$ext.'"';
+                $body .= '; filename="'.basename($b['filename']).'"';
             }
             if (isset($b['headers']) && is_array($b['headers'])) {
                 foreach ($b['headers'] as $header) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -791,7 +791,7 @@ class Client
         }
 
         // Prepare payload for the upload request.
-        $boundary = $this->_parent->uuid;
+        $boundary = Utils::generateMultipartBoundary();
         $bodies = [
             [
                 'type' => 'form-data',
@@ -801,7 +801,7 @@ class Client
             [
                 'type' => 'form-data',
                 'name' => '_uuid',
-                'data' => $boundary,
+                'data' => $this->_parent->uuid,
             ],
             [
                 'type' => 'form-data',
@@ -900,7 +900,7 @@ class Client
         // NOTE: NO INTERNAL DATA IS NEEDED HERE YET.
 
         // Prepare payload for the "pre-upload" request.
-        $boundary = $this->_parent->uuid;
+        $boundary = Utils::generateMultipartBoundary();
         $uploadId = Utils::generateUploadId();
         $bodies = [
             [
@@ -916,7 +916,7 @@ class Client
             [
                 'type' => 'form-data',
                 'name' => '_uuid',
-                'data' => $boundary,
+                'data' => $this->_parent->uuid,
             ],
         ];
         if ($targetFeed == 'album') {
@@ -1251,10 +1251,10 @@ class Client
         }
 
         // Prepare payload for the upload request.
-        $boundary = $this->_parent->uuid;
+        $boundary = Utils::generateMultipartBoundary();
         $uData = json_encode([
             '_csrftoken' => $this->_parent->token,
-            '_uuid'      => $boundary,
+            '_uuid'      => $this->_parent->uuid,
             '_uid'       => $this->_parent->account_id,
         ]);
         $bodies = [
@@ -1371,7 +1371,7 @@ class Client
         // SO WE CONSTRUCT THEIR FINAL $bodies STEP BY STEP TO AVOID
         // CODE REPETITION. BUT RECKLESS FUTURE CHANGES BELOW COULD
         // BREAK *ALL* REQUESTS IF YOU ARE NOT *VERY* CAREFUL!!!
-        $boundary = $this->_parent->uuid;
+        $boundary = Utils::generateMultipartBoundary();
         $bodies = [];
         if ($shareType == 'share') {
             $bodies[] = [

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -5,6 +5,20 @@ namespace InstagramAPI;
 class Utils
 {
     /**
+     * Used for multipart boundary generation.
+     *
+     * @const string
+     */
+    const BOUNDARY_CHARS = '-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    /**
+     * Length of generated multipart boundary.
+     *
+     * @const int
+     */
+    const BOUNDARY_LENGTH = 30;
+
+    /**
      * Name of the detected ffmpeg executable, or FALSE if none found.
      *
      * @var string|bool|null
@@ -24,6 +38,22 @@ class Utils
     public static function generateUploadId()
     {
         return number_format(round(microtime(true) * 1000), 0, '', '');
+    }
+
+    /**
+     * Generates random multipart boundary string.
+     *
+     * @return string
+     */
+    public static function generateMultipartBoundary()
+    {
+        $result = '';
+        $max = strlen(self::BOUNDARY_CHARS) - 1;
+        for ($i = 0; $i < self::BOUNDARY_LENGTH; ++$i) {
+            $result .= self::BOUNDARY_CHARS[mt_rand(0, $max)];
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This one is for @mgp25.

It seems, device id is no longer used as a multipart boundary. 2265154 replaces it with random string.

Also, it seems there was a bug that forced all uploaded filenames to be `pending_media_*.jpg`. 2f1884a fixes it.