### PR TITLE
Fix duplicate response properties

### DIFF
--- a/src/Response/ChallengeResponse.php
+++ b/src/Response/ChallengeResponse.php
@@ -9,6 +9,4 @@ use InstagramAPI\ResponseTrait;
 class ChallengeResponse extends AutoPropertyHandler implements ResponseInterface
 {
     use ResponseTrait;
-
-    public $status;
 }

--- a/src/Response/MediaInfoResponse.php
+++ b/src/Response/MediaInfoResponse.php
@@ -25,7 +25,6 @@ class MediaInfoResponse extends AutoPropertyHandler implements ResponseInterface
     use ResponseTrait;
 
     public $auto_load_more_enabled;
-    public $status;
     public $num_results;
     public $more_available;
     /**

--- a/src/Response/UploadVideoResponse.php
+++ b/src/Response/UploadVideoResponse.php
@@ -30,5 +30,4 @@ class UploadVideoResponse extends AutoPropertyHandler implements ResponseInterfa
      */
     public $configure_delay_ms;
     public $result;
-    public $message;
 }


### PR DESCRIPTION
Closes #1316

Some classes had double had double had double ( ;) ) definitions of
$status and $message, even though they were inheriting those properties
from ResponseTrait.

I did a text search of the whole Response folder and removed the extra
$status and $message from any class that uses ResponseTrait. This fixes
the issue!