### PR TITLE
Various improvements

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -449,6 +449,9 @@ class Instagram
             // Call log attribution API so a csrftoken is put in our cookie jar.
             $this->internal->logAttribution();
 
+            // Uncomment this call when IG_VERSION >= 10.24.0
+            //$this->internal->readMsisdnHeader();
+
             try {
                 $response = $this->request('accounts/login/')
                     ->setNeedsAuth(false)

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -615,7 +615,7 @@ class Instagram
             // This also lets us detect if we're still logged in with a valid session.
             try {
                 $this->timeline->getTimelineFeed(null, [
-                    'is_pull_to_refresh' => true,
+                    'is_pull_to_refresh' => mt_rand(1, 3) < 3,
                 ]);
             } catch (\InstagramAPI\Exception\LoginRequiredException $e) {
                 // If our session cookies are expired, we were now told to login,

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -444,7 +444,7 @@ class Instagram
 
         // Perform a full relogin if necessary.
         if (!$this->isLoggedIn || $forceLogin) {
-            $this->internal->syncFeatures(true);
+            $this->internal->syncDeviceFeatures(true);
 
             // Call log attribution API so a csrftoken is put in our cookie jar.
             $this->internal->logAttribution();
@@ -590,7 +590,7 @@ class Instagram
         // You have been warned.
         if ($justLoggedIn) {
             // Perform the "user has just done a full login" API flow.
-            $this->internal->syncFeatures();
+            $this->internal->syncUserFeatures();
             $this->people->getAutoCompleteUserList();
             $this->story->getReelsTrayFeed();
             $this->direct->getRecentRecipients();
@@ -642,7 +642,8 @@ class Instagram
             // experiments never get synced and updated. So sync periodically.
             $lastExperimentsTime = $this->settings->get('last_experiments');
             if (is_null($lastExperimentsTime) || (time() - $lastExperimentsTime) > self::EXPERIMENTS_REFRESH) {
-                $this->internal->syncFeatures();
+                $this->internal->syncUserFeatures();
+                $this->internal->syncDeviceFeatures();
             }
         }
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -614,7 +614,9 @@ class Instagram
             // Act like a real logged in app client refreshing its news timeline.
             // This also lets us detect if we're still logged in with a valid session.
             try {
-                $this->timeline->getTimelineFeed();
+                $this->timeline->getTimelineFeed(null, [
+                    'is_pull_to_refresh' => true,
+                ]);
             } catch (\InstagramAPI\Exception\LoginRequiredException $e) {
                 // If our session cookies are expired, we were now told to login,
                 // so handle that by running a forced relogin in that case!

--- a/src/Request/Internal.php
+++ b/src/Request/Internal.php
@@ -896,6 +896,56 @@ class Internal extends RequestCollection
     }
 
     /**
+     * Reads MSISDN header.
+     *
+     * WARNING. DON'T USE. UNDER RESEARCH.
+     *
+     * @param string $subnoKey Encoded subscriber number.
+     *
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\MsisdnHeaderResponse
+     *
+     * @since 10.24.0 app version.
+     */
+    public function readMsisdnHeader(
+        $subnoKey = null)
+    {
+        $request = $this->ig->request('accounts/read_msisdn_header/')
+            ->setNeedsAuth(false)
+            // UUID is used as device_id intentionally.
+            ->addPost('device_id', $this->ig->uuid)
+            ->addPost('_csrftoken', $this->ig->client->getToken());
+        if ($subnoKey !== null) {
+            $request->addPost('subno_key', $subnoKey);
+        }
+
+        return $request->getResponse(new Response\MsisdnHeaderResponse());
+    }
+
+    /**
+     * Bootstraps MSISDN header.
+     *
+     * WARNING. DON'T USE. UNDER RESEARCH.
+     *
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\MsisdnHeaderResponse
+     *
+     * @since 10.24.0 app version.
+     */
+    public function bootstrapMsisdnHeader()
+    {
+        $request = $this->ig->request('accounts/msisdn_header_bootstrap/')
+            ->setNeedsAuth(false)
+            // UUID is used as device_id intentionally.
+            ->addPost('device_id', $this->ig->uuid)
+            ->addPost('_csrftoken', $this->ig->client->getToken());
+
+        return $request->getResponse(new Response\MsisdnHeaderResponse());
+    }
+
+    /**
      * Get megaphone log.
      *
      * @throws \InstagramAPI\Exception\InstagramException

--- a/src/Response/MsisdnHeaderResponse.php
+++ b/src/Response/MsisdnHeaderResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace InstagramAPI\Response;
+
+use InstagramAPI\AutoPropertyHandler;
+use InstagramAPI\ResponseInterface;
+use InstagramAPI\ResponseTrait;
+
+/**
+ * @method string getPhoneNumber()
+ * @method string getUrl()
+ * @method bool isPhoneNumber()
+ * @method bool isUrl()
+ * @method setPhoneNumber(string $value)
+ * @method setUrl(string $value)
+ */
+class MsisdnHeaderResponse extends AutoPropertyHandler implements ResponseInterface
+{
+    use ResponseTrait;
+
+    /** @var string */
+    public $phone_number;
+
+    /** @var string */
+    public $url;
+}


### PR DESCRIPTION
1. bc97485 splits `syncFeatures()` in two methods and calls them both on experiments refresh.
2. 1547bee adds new methods used in pre-login flow (since 10.24.0). These methods are marked under research and not used for now.
3. 6e2371b updates our most used method `getTimelineFeed()`.