### PR TITLE
Improve ServerMessageThrower

### DIFF
--- a/devtools/exceptionTest.php
+++ b/devtools/exceptionTest.php
@@ -8,28 +8,33 @@ require __DIR__.'/../vendor/autoload.php';
 use InstagramAPI\Exception\ServerMessageThrower;
 
 /*
- * Emulates various server message strings and verifies that they're mapped
+ * Emulates various server responses and verifies that they're mapped
  * correctly by the ServerMessageThrower's parser.
  */
 $exceptionsToTest = [
-    'InstagramAPI\\Exception\\LoginRequiredException'      => ['login_required'],
-    'InstagramAPI\\Exception\\FeedbackRequiredException'   => ['feedback_required'],
-    'InstagramAPI\\Exception\\CheckpointRequiredException' => ['checkpoint_required'],
-    'InstagramAPI\\Exception\\IncorrectPasswordException'  => ['The password you entered is incorrect. Please try again.'],
-    'InstagramAPI\\Exception\\AccountDisabledException'    => ['Your account has been disabled for violating our terms. Learn how you may be able to restore your account.'],
+    'InstagramAPI\\Exception\\LoginRequiredException'      => '{"message":"login_required", "logout_reason": 2, "status": "fail"}',
+    'InstagramAPI\\Exception\\FeedbackRequiredException'   => '{"message":"feedback_required","spam":true,"feedback_title":"You\u2019re Temporarily Blocked","feedback_message":"It looks like you were misusing this feature by going too fast. You\u2019ve been blocked from using it.\n\nLearn more about blocks in the Help Center. We restrict certain content and actions to protect our community. Tell us if you think we made a mistake.","feedback_url":"WUT","feedback_appeal_label":"Report problem","feedback_ignore_label":"OK","feedback_action":"report_problem","status":"fail"}',
+    'InstagramAPI\\Exception\\CheckpointRequiredException' => '{"message":"checkpoint_required","checkpoint_url":"WUT","lock":true,"status":"fail","error_type":"checkpoint_challenge_required"}',
+    'InstagramAPI\\Exception\\IncorrectPasswordException'  => '{"message":"The password you entered is incorrect. Please try again.","invalid_credentials":true,"error_title":"Incorrect password for WUT","buttons":[{"title":"Try Again","action":"dismiss"}],"status":"fail","error_type":"bad_password"}',
+    'InstagramAPI\\Exception\\AccountDisabledException'    => '{"message":"Your account has been disabled for violating our terms. Learn how you may be able to restore your account."}',
+    'InstagramAPI\\Exception\\InvalidUserException'        => '{"message":"The username you entered doesn\'t appear to belong to an account. Please check your username and try again.","invalid_credentials":true,"error_title":"Incorrect Username","buttons":[{"title":"Try Again","action":"dismiss"}],"status":"fail","error_type":"invalid_user"}',
+    'InstagramAPI\\Exception\\SentryBlockException'        => '{"message":"Sorry, there was a problem with your request.","status":"fail","error_type":"sentry_block"}',
 ];
 
-foreach ($exceptionsToTest as $exceptionClassName => $testMessages) {
-    foreach ($testMessages as $testMessage) {
-        try {
-            ServerMessageThrower::autoThrow(null, $testMessage);
-        } catch (\InstagramAPI\Exception\InstagramException $e) {
-            $thisClassName = get_class($e);
-            if ($exceptionClassName == $thisClassName) {
-                echo "{$exceptionClassName}: OK!\n";
-            } else {
-                echo "{$exceptionClassName}: Got {$thisClassName} instead!\n";
-            }
+$mapper = new \JsonMapper();
+$mapper->bStrictNullTypes = false;
+foreach ($exceptionsToTest as $exceptionClassName => $testResponse) {
+    $testResponse = \InstagramAPI\Client::api_body_decode($testResponse);
+    $response = $mapper->map($testResponse, new \InstagramAPI\Response\GenericResponse());
+    $response->setFullResponse($testResponse);
+    try {
+        ServerMessageThrower::autoThrow(null, $response->getMessage(), $response);
+    } catch (\InstagramAPI\Exception\InstagramException $e) {
+        $thisClassName = get_class($e);
+        if ($exceptionClassName == $thisClassName) {
+            echo "{$exceptionClassName}: OK!\n";
+        } else {
+            echo "{$exceptionClassName}: Got {$thisClassName} instead!\n";
         }
     }
 }

--- a/devtools/exceptionTest.php
+++ b/devtools/exceptionTest.php
@@ -19,6 +19,7 @@ $exceptionsToTest = [
     'InstagramAPI\\Exception\\AccountDisabledException'    => '{"message":"Your account has been disabled for violating our terms. Learn how you may be able to restore your account."}',
     'InstagramAPI\\Exception\\InvalidUserException'        => '{"message":"The username you entered doesn\'t appear to belong to an account. Please check your username and try again.","invalid_credentials":true,"error_title":"Incorrect Username","buttons":[{"title":"Try Again","action":"dismiss"}],"status":"fail","error_type":"invalid_user"}',
     'InstagramAPI\\Exception\\SentryBlockException'        => '{"message":"Sorry, there was a problem with your request.","status":"fail","error_type":"sentry_block"}',
+    'InstagramAPI\\Exception\\InvalidSmsCodeException'     => '{"message":"Please check the security code we sent you and try again.","status":"fail","error_type":"sms_code_validation_code_invalid"}',
 ];
 
 $mapper = new \JsonMapper();

--- a/src/Exception/InvalidSmsCodeException.php
+++ b/src/Exception/InvalidSmsCodeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace InstagramAPI\Exception;
+
+class InvalidSmsCodeException extends RequestException
+{
+}

--- a/src/Exception/ServerMessageThrower.php
+++ b/src/Exception/ServerMessageThrower.php
@@ -48,6 +48,11 @@ class ServerMessageThrower
             '/password(.*?)incorrect/', // message
             'bad_password', // error_type
         ],
+        'InvalidSmsCodeException'      => [
+            // ""Please check the security code we sent you and try again".
+            '/check(.*?)security(.*?)code/', // message
+            'sms_code_validation_code_invalid', // error_type
+        ],
         'AccountDisabledException'     => [
             // "Your account has been disabled for violating our terms"
             '/account(.*?)disabled(.*?)violating/',

--- a/src/Exception/ServerMessageThrower.php
+++ b/src/Exception/ServerMessageThrower.php
@@ -106,13 +106,13 @@ class ServerMessageThrower
                         // Regex check.
                         if (preg_match($pattern, $message)) {
                             $exceptionClass = $className;
-                            break 2;
+                            break 3;
                         }
                     } else {
                         // Regular string search.
                         if (strpos($message, $pattern) !== false) {
                             $exceptionClass = $className;
-                            break 2;
+                            break 3;
                         }
                     }
                 }


### PR DESCRIPTION
Existing detection method that works on human-readable server messages is unreliable. In the same time, almost all server errors contain `error_type` field. So we should use it as additional source to check against.

Also this PR fixes detection for `InvalidUserException` and adds new `InvalidSmsCodeException`. And I used real responses for `exceptionTest` script. I don't have responses for `AccountDisabledException` and `ForcedPasswordResetException` though.