### PR TITLE
Realtime: Make WebSocket client optional

### DIFF
--- a/src/Realtime.php
+++ b/src/Realtime.php
@@ -5,6 +5,7 @@ namespace InstagramAPI;
 use Evenement\EventEmitterInterface;
 use Evenement\EventEmitterTrait;
 use InstagramAPI\Realtime\Client as RealtimeClient;
+use InstagramAPI\Response\Model\Subscription;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\Timer\TimerInterface;
 use React\Promise\FulfilledPromise;
@@ -52,6 +53,9 @@ class Realtime implements EventEmitterInterface
 
     /** @var TimerInterface */
     protected $_reloginTimer;
+
+    /** @var bool */
+    protected $_wsEnabled;
 
     /** @var bool */
     protected $_mqttEnabled;
@@ -188,18 +192,26 @@ class Realtime implements EventEmitterInterface
     protected function _init()
     {
         $this->_instagram->login();
+        // Fetch inbox for subscription and sequence ID.
+        $inbox = $this->_instagram->direct->getInbox();
         // Check for MQTT experiments.
         $experiments = $this->_instagram->experiments;
         $mqttFeatures = isset($experiments['ig_android_mqtt_skywalker'])
             ? $experiments['ig_android_mqtt_skywalker'] : [];
+        $this->_wsEnabled = RealtimeClient::isFeatureEnabled($mqttFeatures, 'is_telegraph_enabled');
         $this->_mqttEnabled = RealtimeClient::isFeatureEnabled($mqttFeatures, 'is_enabled');
         $this->_mqttSendEnabled = $this->_mqttEnabled && RealtimeClient::isFeatureEnabled($mqttFeatures, 'is_send_enabled');
         $this->_mqttReceiveEnabled = $this->_mqttEnabled && RealtimeClient::isFeatureEnabled($mqttFeatures, 'is_receive_enabled');
         // WebSocket Client.
-        $this->debug('[rtc] starting websocket client');
-        $this->_wsClient = new RealtimeClient\WebSocket('webs', $this, $this->_instagram, [
-            'isMqttReceiveEnabled' => $this->_mqttReceiveEnabled,
-        ]);
+        if ($this->_wsEnabled && $inbox->subscription instanceof Subscription) {
+            $this->debug('[rtc] starting websocket client');
+            $this->_wsClient = new RealtimeClient\WebSocket('webs', $this, $this->_instagram, [
+                'subscription'         => $inbox->subscription,
+                'isMqttReceiveEnabled' => $this->_mqttReceiveEnabled,
+            ]);
+        } elseif ($this->_wsEnabled) {
+            $this->debug('[rtc] telegraph is enabled without subscription, skipping it');
+        }
         // MQTT Client.
         if ($this->_mqttEnabled) {
             $mqttLiveFeatures = isset($experiments['ig_android_skywalker_live_event_start_end'])
@@ -211,6 +223,10 @@ class Realtime implements EventEmitterInterface
                 'isMqttLiveEnabled'    => RealtimeClient::isFeatureEnabled($mqttLiveFeatures, 'is_enabled'),
                 'mqttRoute'            => isset($mqttFeatures['mqtt_route']) ? $mqttFeatures['mqtt_route'] : null,
             ]);
+        }
+
+        if ($this->_wsClient === null && $this->_mqttClient === null) {
+            throw new \RuntimeException('Both MQTT and WS are disabled');
         }
     }
 
@@ -239,10 +255,12 @@ class Realtime implements EventEmitterInterface
         array $command)
     {
         $command = static::jsonEncode($command);
-        if ($this->_mqttClient === null || !$this->_mqttSendEnabled) {
+        if ($this->_wsClient !== null && !$this->_mqttSendEnabled) {
             return $this->_wsClient->sendCommand('X'.$command);
-        } else {
+        } elseif ($this->_mqttClient !== null) {
             return $this->_mqttClient->sendCommand($command);
+        } else {
+            return false;
         }
     }
 

--- a/src/Realtime/Client/WebSocket.php
+++ b/src/Realtime/Client/WebSocket.php
@@ -39,9 +39,13 @@ class WebSocket extends Client
             $this->_isMqttReceiveEnabled = false;
         }
 
-        // Init subscription.
+        // Subscription.
+        if (!isset($params['subscription']) || !$params['subscription'] instanceof Subscription) {
+            throw new \InvalidArgumentException('Please provide a valid subscription model.');
+        }
+        $this->_subscription = $params['subscription'];
+
         $this->_isSubscribed = false;
-        $this->_initSubscription();
     }
 
     /**
@@ -212,16 +216,6 @@ class WebSocket extends Client
         $this->debug('Sequence for topic "%s" is updated to "%s"', $topic, $this->_subscription->sequence);
     }
 
-    protected function _initSubscription()
-    {
-        $inbox = $this->_instagram->direct->getInbox();
-        $subscription = $inbox->subscription;
-        if (!$subscription instanceof Subscription) {
-            throw new \InvalidArgumentException('Can not subscribe to inbox.');
-        }
-        $this->_subscription = $subscription;
-    }
-
     /**
      * Refresh subscription.
      */
@@ -229,7 +223,12 @@ class WebSocket extends Client
     {
         $this->_isSubscribed = false;
         $this->_unsubscribe($this->_subscription->topic);
-        $this->_initSubscription();
+        $inbox = $this->_instagram->direct->getInbox();
+        $subscription = $inbox->subscription;
+        if (!$subscription instanceof Subscription) {
+            throw new \InvalidArgumentException('Can not subscribe to inbox.');
+        }
+        $this->_subscription = $subscription;
     }
 
     /** {@inheritdoc} */


### PR DESCRIPTION
Instagram is deprecating its WebSocket client (so-called Telegraph) in favor of MQTT one (is being used by Facebook Messenger for a long time) since 10.26.0.

Fixes #1353.