### PR TITLE
Do not use isset() on consts

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -163,7 +163,7 @@ class Request
     public function setVersion(
         $apiVersion)
     {
-        if (!isset(Constants::API_URLS[$apiVersion])) {
+        if (!array_key_exists($apiVersion, Constants::API_URLS)) {
             throw new \InvalidArgumentException(sprintf('"%d" is not a supported API version.', $apiVersion));
         }
         $this->_apiVersion = $apiVersion;


### PR DESCRIPTION
It fixes a bug introduced in #1390: although PHP7 allows it, we must use `array_key_exists()` on const arrays.

Thanks to @rudemex for pointing it in #1410.