### PR TITLE
Check resources before closing them

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -512,7 +512,9 @@ class Request
         }
 
         foreach ($this->_handles as $handle) {
-            fclose($handle);
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
         }
         $this->_resetHandles();
     }

--- a/src/Request/Internal.php
+++ b/src/Request/Internal.php
@@ -1305,7 +1305,9 @@ class Internal extends RequestCollection
             }
         } finally {
             // Guaranteed to release handle even if something bad happens above!
-            fclose($handle);
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
         }
 
         throw new \InstagramAPI\Exception\UploadFailedException(sprintf(
@@ -1417,7 +1419,9 @@ class Internal extends RequestCollection
             }
         } finally {
             // Guaranteed to release handle even if something bad happens above!
-            fclose($handle);
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
         }
 
         throw new \InstagramAPI\Exception\UploadFailedException(sprintf(


### PR DESCRIPTION
It turned out that Guzzle's streams close supplied handles in `__destruct()`, so there is a chance that handle is already has been closed when we are trying to close it. And that leads to `supplied resource is not a valid stream resource` errors.