### PR TITLE
Do not use JsonMapper

### DIFF
--- a/devtools/generateAutoPropertyHandlerMethods.php
+++ b/devtools/generateAutoPropertyHandlerMethods.php
@@ -1,0 +1,521 @@
+<?php
+
+set_time_limit(0);
+date_default_timezone_set('UTC');
+
+require __DIR__.'/../vendor/autoload.php';
+
+$mode = isset($argv[1]) ? $argv[1] : AutoMethods::MODE_APPEND;
+
+$updater = new AutoMethods(__DIR__.'/../src/', $mode);
+$processedFiles = $updater->run();
+exit((int) ($mode !== AutoMethods::MODE_VALIDATE || !count($processedFiles)));
+
+class AutoMethods
+{
+    const MODE_APPEND = 'append';
+    const MODE_REWRITE = 'rewrite';
+    const MODE_VALIDATE = 'validate';
+
+    const PADDING = "XXXPADDINGXXX\n";
+
+    /**
+     * @var string
+     */
+    private $_dir;
+
+    /**
+     * @var string
+     */
+    private $_mode;
+
+    /**
+     * @return array
+     */
+    public function getAvailableModes()
+    {
+        return [
+            self::MODE_APPEND,
+            self::MODE_REWRITE,
+            self::MODE_VALIDATE,
+        ];
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param string $dir  Directory to process.
+     * @param string $mode Updated mode
+     */
+    public function __construct(
+        $dir,
+        $mode)
+    {
+        $this->_dir = realpath($dir);
+        if ($this->_dir === false) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid path.', $dir));
+        }
+        if (!in_array($mode, $this->getAvailableModes())) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid mode.', $mode));
+        }
+        $this->_mode = $mode;
+    }
+
+    /**
+     * Convert file path to class name.
+     *
+     * @param string $filePath
+     *
+     * @return string
+     */
+    private function _extractClassName(
+        $filePath)
+    {
+        return '\InstagramAPI'.str_replace('/', '\\', substr($filePath, strlen($this->_dir), -4));
+    }
+
+    /**
+     * Extract property type from its PHPDoc.
+     *
+     * @param ReflectionProperty $property
+     *
+     * @return string
+     */
+    private function _getType(
+        ReflectionProperty $property)
+    {
+        $phpDoc = $property->getDocComment();
+        if ($phpDoc === false || !preg_match('#@var\s+([^\s]+)#i', $phpDoc, $matches)) {
+            $type = 'mixed';
+        } else {
+            $type = $matches[1];
+        }
+
+        return $type;
+    }
+
+    /**
+     * Converts underscores to camel cases.
+     *
+     * @param string $property
+     *
+     * @return string
+     */
+    private function _camelCase(
+        $property)
+    {
+        // Trim any leading underscores and save their count, because it's a special case.
+        $result = ltrim($property, '_');
+        $leadingUnderscores = strlen($property) - strlen($result);
+        if (strlen($result)) {
+            // Convert all chars prefixed with underscore to upper case.
+            $result = preg_replace_callback('#_([^_])#', function ($matches) {
+                return strtoupper($matches[1]);
+            }, $result);
+            // Convert fist char to upper case.
+            $result[0] = strtoupper($result[0]);
+        }
+        // Restore leading underscores (if any).
+        if ($leadingUnderscores) {
+            $result = str_pad($result, strlen($result) + $leadingUnderscores, '_', STR_PAD_LEFT);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Generate a list of methods signatures based on properties list.
+     *
+     * @param ReflectionClass $reflection
+     *
+     * @return array Map of method name => [source, type]
+     */
+    private function _generateMethodsSignatures(
+        ReflectionClass $reflection)
+    {
+        $result = [];
+        $properties = $reflection->getProperties();
+        $parent = $reflection->getParentClass();
+        foreach ($properties as $property) {
+            if (strpos($property->getDocComment(), '@internal') !== false) {
+                continue;
+            }
+            $propertyName = $property->getName();
+            // Determine property type.
+            $type = $this->_getType($property);
+            // Skip properties available in parent class.
+            if ($parent->hasProperty($propertyName)) {
+                $parentType = $this->_getType($parent->getProperty($propertyName));
+                if ($parentType === $type) {
+                    continue;
+                }
+            }
+
+            // Normalize property name.
+            $normalizedName = $this->_camelCase($propertyName);
+            $signature = [$propertyName, $type];
+            // getPropertyName() method.
+            $getter = 'get'.$normalizedName;
+            $result[$getter] = $signature;
+
+            // setPropertyName() method.
+            $setter = 'set'.$normalizedName;
+            $result[$setter] = $signature;
+
+            // isPropertyName() method.
+            $iser = 'is'.$normalizedName;
+            $result[$iser] = $signature;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param ReflectionClass $reflection
+     *
+     * @return ReflectionMethod[]
+     */
+    private function _getExistingMethods(
+        ReflectionClass $reflection)
+    {
+        $result = [];
+        foreach ($reflection->getMethods() as $method) {
+            $result[$method->getName()] = $method;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     * @param array            $lines
+     *
+     * @return array
+     */
+    private function _removeExistingMethod(
+        ReflectionMethod $method,
+        array $lines)
+    {
+        $result = $lines;
+        $from = $method->getStartLine();
+        $phpDoc = $method->getDocComment();
+        if (!empty($phpDoc)) {
+            $from -= substr_count($method->getDocComment(), "\n") + 1;
+        }
+        $to = $method->getEndLine();
+
+        for ($i = $from - 1; $i < $to; ++$i) {
+            $result[$i] = self::PADDING;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $lines
+     *
+     * @return array
+     */
+    private function _filterEmptyLines(
+        array $lines)
+    {
+        $result = array_filter($lines, function ($line) {
+            return $line !== self::PADDING;
+        });
+        $prevLine = '';
+        $result = array_filter($result, function ($line) use (&$prevLine) {
+            $line = trim($line);
+            if ($prevLine === '' && $line === '') {
+                return false;
+            } else {
+                $prevLine = $line;
+
+                return true;
+            }
+        });
+
+        return $result;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    private function _isSimple(
+        $type)
+    {
+        return in_array($type, ['string', 'bool', 'int', 'float', 'double', 'array']);
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    private function _isArray(
+        $type)
+    {
+        return substr($type, -2) === '[]' && !$this->_isMixed($type);
+    }
+
+    /**
+     * @param $type
+     *
+     * @return bool
+     */
+    private function _isMixed(
+        $type)
+    {
+        return $type === 'mixed' || strpos($type, '|') !== false;
+    }
+
+    /**
+     * @param $source
+     * @param $type
+     *
+     * @return array
+     */
+    private function _generateArrayGetter(
+        $source,
+        $type)
+    {
+        $result = [];
+        $result[] = "            if (is_array(\$this->_jsonData->{$source})) {\n";
+        $result[] = "                \$this->{$source} = [];\n";
+        $result[] = "                foreach (\$this->_jsonData->{$source} as \$idx => \$value) {\n";
+        if ($this->_isMixed($type) || $this->_isSimple($type)) {
+            $result[] = "                    \$this->{$source}[\$idx] = \$value;\n";
+        } elseif ($this->_isArray($type)) {
+            throw new \RuntimeException('No support for inner arrays.');
+        } else {
+            $result[] = "                    \$this->{$source}[\$idx] = new {$type}(\$value);\n";
+        }
+        $result[] = "                }\n";
+        $result[] = "            } else {\n";
+        $result[] = "                \$this->{$source} = null;\n";
+        $result[] = "            }\n";
+
+        return $result;
+    }
+
+    /**
+     * @param $methodName
+     * @param $source
+     * @param $type
+     *
+     * @return array
+     */
+    private function _generateGetter(
+        $methodName,
+        $source,
+        $type)
+    {
+        $result = [];
+        $result[] = "\n";
+        $result[] = "    /**\n";
+        $result[] = "     * @return {$type}\n";
+        $result[] = "     */\n";
+        $result[] = "    public function {$methodName}()\n";
+        $result[] = "    {\n";
+        $result[] = "        if (\$this->{$source} !== null) {\n";
+        $result[] = "            return \$this->{$source};\n";
+        $result[] = "        } elseif (isset(\$this->_jsonData->{$source})) {\n";
+        if ($this->_isMixed($type) || $this->_isSimple($type)) {
+            $result[] = "            \$this->{$source} = \$this->_jsonData->{$source};\n";
+        } elseif ($this->_isArray($type)) {
+            $result = array_merge($result, $this->_generateArrayGetter($source, substr($type, 0, -2)));
+        } else {
+            $result[] = "            \$this->{$source} = new {$type}(\$this->_jsonData->{$source});\n";
+        }
+        $result[] = "\n";
+        $result[] = "            return \$this->{$source};\n";
+        $result[] = "        } else {\n";
+        $result[] = "            return null;\n";
+        $result[] = "        }\n";
+        $result[] = "    }\n";
+        $reuslt[] = "\n";
+
+        return $result;
+    }
+
+    /**
+     * @param $methodName
+     * @param $source
+     * @param $type
+     *
+     * @return array
+     */
+    private function _generateSetter(
+        $methodName,
+        $source,
+        $type)
+    {
+        if ($this->_isArray($type) || $type === 'array') {
+            $valueType = 'array ';
+        } elseif ($this->_isMixed($type) || $this->_isSimple($type)) {
+            $valueType = '';
+        } else {
+            $valueType = $type.' ';
+        }
+        $result = [];
+        $result[] = "\n";
+        $result[] = "    /**\n";
+        $result[] = "     * @param {$type} \$value\n";
+        $result[] = "     *\n";
+        $result[] = "     * @return static\n";
+        $result[] = "     */\n";
+        $result[] = "    public function {$methodName}(\n";
+        $result[] = "        {$valueType}\$value)\n";
+        $result[] = "    {\n";
+        $result[] = "        \$this->{$source} = \$value;\n";
+        $result[] = "        \$this->_jsonData->{$source} = \$value;\n";
+        $result[] = "\n";
+        $result[] = "        return \$this;\n";
+        $result[] = "    }\n";
+        $reuslt[] = "\n";
+
+        return $result;
+    }
+
+    /**
+     * @param $methodName
+     * @param $source
+     *
+     * @return array
+     */
+    private function _generateIser(
+        $methodName,
+        $source)
+    {
+        $result = [];
+        $result[] = "\n";
+        $result[] = "    /**\n";
+        $result[] = "     * @return bool\n";
+        $result[] = "     */\n";
+        $result[] = "    public function {$methodName}()\n";
+        $result[] = "    {\n";
+        $result[] = "        return isset(\$this->_jsonData->{$source}) && \$this->_jsonData->{$source};\n";
+        $result[] = "    }\n";
+        $reuslt[] = "\n";
+
+        return $result;
+    }
+
+    /**
+     * @param string $methodName
+     * @param array  $signature
+     * @param array  $lines
+     *
+     * @return array
+     */
+    private function _generateMethodCode(
+        $methodName,
+        array $signature,
+        array $lines)
+    {
+        list($source, $type) = $signature;
+        if (!substr_compare($methodName, 'get', 0, 3)) {
+            $method = $this->_generateGetter($methodName, $source, $type);
+        } elseif (!substr_compare($methodName, 'set', 0, 3)) {
+            $method = $this->_generateSetter($methodName, $source, $type);
+        } elseif (!substr_compare($methodName, 'is', 0, 2)) {
+            $method = $this->_generateIser($methodName, $source);
+        } else {
+            $method = [];
+        }
+
+        return $method;
+    }
+
+    /**
+     * @param string             $filePath
+     * @param array              $newMethods
+     * @param ReflectionMethod[] $existingMethods
+     * @param int                $insertAt
+     *
+     * @return bool
+     */
+    private function _generateMethods(
+        $filePath,
+        array $newMethods,
+        array $existingMethods,
+        $insertAt)
+    {
+        $lines = file($filePath);
+
+        foreach ($newMethods as $methodName => $signature) {
+            if (isset($existingMethods[$methodName])) {
+                $lines = $this->_removeExistingMethod($existingMethods[$methodName], $lines);
+            }
+            $method = $this->_generateMethodCode($methodName, $signature, $lines);
+            array_splice($lines, $insertAt - 1, 0, $method);
+            $insertAt += count($method);
+        }
+
+        $lines = $this->_filterEmptyLines($lines);
+        file_put_contents($filePath, implode('', $lines));
+
+        return true;
+    }
+
+    /**
+     * Process single file.
+     *
+     * @param string          $filePath
+     * @param ReflectionClass $reflection
+     *
+     * @return bool
+     */
+    private function _processFile(
+        $filePath,
+        ReflectionClass $reflection)
+    {
+        $allMethods = $this->_generateMethodsSignatures($reflection);
+        $existingMethods = $this->_getExistingMethods($reflection);
+        $diff = array_diff_key($allMethods, $existingMethods);
+        switch ($this->_mode) {
+            case self::MODE_APPEND:
+                $result = count($diff)
+                    ? $this->_generateMethods($filePath, $diff, $existingMethods, $reflection->getEndLine())
+                    : true;
+                break;
+            case self::MODE_REWRITE:
+                $result = count($allMethods)
+                    ? $this->_generateMethods($filePath, $allMethods, $existingMethods, $reflection->getEndLine())
+                    : true;
+                break;
+            case self::MODE_VALIDATE:
+                $result = !count($diff);
+                break;
+            default:
+                throw new RuntimeException(sprintf('Unknown mode "%s".', $this->_mode));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Process all *.php files in given path.
+     *
+     * @return array
+     */
+    public function run()
+    {
+        $directoryIterator = new RecursiveDirectoryIterator($this->_dir);
+        $recursiveIterator = new RecursiveIteratorIterator($directoryIterator);
+        $phpIterator = new RegexIterator($recursiveIterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH);
+
+        $result = [];
+        foreach ($phpIterator as $filePath => $dummy) {
+            $reflection = new ReflectionClass($this->_extractClassName($filePath));
+            if ($reflection->isSubclassOf(\InstagramAPI\AutoPropertyHandler::class)) {
+                if ($this->_processFile($filePath, $reflection)) {
+                    $result[] = $filePath;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/AutoPropertyHandler.php
+++ b/src/AutoPropertyHandler.php
@@ -30,119 +30,18 @@ namespace InstagramAPI;
 class AutoPropertyHandler
 {
     /**
-     * __CALL is invoked when attempting to access missing functions.
-     *
-     * This handler auto-maps setters and getters for object properties.
-     *
-     * NOTE: Don't worry about performance. This whole function takes about
-     * 0.025 MILLIseconds per property, which actually compares very favorably
-     * to native accessor functions (which take about 0.002 MILLIseconds per
-     * call).
-     *
-     * @param string $functionName Name of the method being called.
-     * @param array  $arguments    Array of arguments passed to the method.
-     *
-     * @throws \Exception If the function type or property name is invalid.
-     *
-     * @return mixed
-     *
-     * @see http://php.net/manual/en/language.oop5.magic.php
+     * @var object|null
      */
-    public function __call(
-        $functionName,
-        $arguments)
-    {
-        // Extract the components of the function they tried to call.
-        $chunks = self::explodeCamelCase($functionName);
-        if ($chunks === false || count($chunks) < 2) {
-            throw new \Exception("Unknown function {$functionName}.");
-        }
-
-        // Determine the type (such as "get") and the property (ie "is_valid").
-        $functionType = array_shift($chunks);
-        $propertyName = implode('_', $chunks); // "is_valid"
-
-        // Some objects have rare camelcase properties, so instead of naming it
-        // "i_tunes_item" they have "iTunesItem" as the property. We'll have to
-        // check for the existence of a camelcase property and use it if found.
-        if (($len = count($chunks)) >= 2) {
-            // Make word 2 and higher start with uppercase ("i,Tunes,Item").
-            // NOTE: Instagram's rule so far is that the first word is always
-            // lowercase when they use camelcase.
-            for ($i = 1; $i < $len; ++$i) {
-                $chunks[$i] = ucfirst($chunks[$i]);
-            }
-            $camelPropertyName = implode('', $chunks); // "iTunesItem"
-            if (property_exists($this, $camelPropertyName)) {
-                $propertyName = $camelPropertyName; // Use this name instead.
-            }
-        }
-
-        // Make sure the requested function has a corresponding object property.
-        if (!property_exists($this, $propertyName)) {
-            throw new \Exception("Unknown function {$functionName}.");
-        }
-
-        // Return the kind of response expected by their desired function.
-        switch ($functionType) {
-        case 'get':
-            return $this->{$propertyName};
-            break;
-        case 'set':
-            $this->{$propertyName} = $arguments[0];
-            break;
-        case 'is':
-            return (bool) $this->{$propertyName};
-            break;
-        default:
-            // Unknown function type prefix...
-            throw new \Exception("Unknown function {$functionName}.");
-        }
-    }
+    protected $_jsonData;
 
     /**
-     * Explodes a string on camelcase boundaries.
+     * Constructor.
      *
-     * Examples:
-     * - "getSome0XThing" => "get", "some0", "x", "thing".
-     * - "getSome0xThing" => "get", "some0x", "thing".
-     *
-     * @param string $inputString
-     *
-     * @return string[]|bool Array with parts if successful, otherwise FALSE.
+     * @param object|null $jsonData
      */
-    public static function explodeCamelCase(
-        $inputString)
+    public function __construct(
+        $jsonData = null)
     {
-        // Split the input into chunks on all camelcase boundaries.
-        // NOTE: The input must be 2+ characters AND have at least one uppercase.
-        $chunks = preg_split('/(?=[A-Z])/', $inputString, -1, PREG_SPLIT_NO_EMPTY);
-        if ($chunks === false) {
-            return false;
-        }
-
-        // Process all individual chunks and make them all completely lowercase.
-        // NOTE: Since all chunks are split on camelcase boundaries above, it
-        // means that each chunk ONLY holds a SINGLE fragment which can ONLY
-        // contain at most a SINGLE capital letter (the chunk's first letter).
-        foreach ($chunks as &$chunk) {
-            $chunk = lcfirst($chunk); // Only first letter may be uppercase.
-        }
-
-        // If there are 2+ chunks and the first (the function type) ends with
-        // trailing underscores, it means that they wanted to access a property
-        // beginning with underscores, so move those to the start of the 2nd
-        // ("property name") chunk instead.
-        if (count($chunks) >= 2) {
-            $oldLen = strlen($chunks[0]);
-            $chunks[0] = rtrim($chunks[0], '_'); // "get_" => "get".
-            $lenDiff = $oldLen - strlen($chunks[0]);
-            if ($lenDiff > 0) {
-                // Move all underscores to prop: "messages" => "_messages":
-                $chunks[1] = str_repeat('_', $lenDiff).$chunks[1];
-            }
-        }
-
-        return $chunks;
+        $this->_jsonData = $jsonData;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -545,7 +545,7 @@ class Client
 
         // Perform mapping of all response properties.
         /** @var ResponseInterface $responseObject */
-        $responseObject = $this->_mapper->map($serverResponse, $baseClass);
+        $responseObject = new $baseClass($serverResponse);
 
         // Save the raw response object as the "getFullResponse()" value.
         $responseObject->setFullResponse($serverResponse);

--- a/src/Response/Model/Experiment.php
+++ b/src/Response/Model/Experiment.php
@@ -4,17 +4,6 @@ namespace InstagramAPI\Response\Model;
 
 use InstagramAPI\AutoPropertyHandler;
 
-/**
- * @method mixed getGroup()
- * @method mixed getName()
- * @method Param[] getParams()
- * @method bool isGroup()
- * @method bool isName()
- * @method bool isParams()
- * @method setGroup(mixed $value)
- * @method setName(mixed $value)
- * @method setParams(Param[] $value)
- */
 class Experiment extends AutoPropertyHandler
 {
     /**
@@ -23,4 +12,125 @@ class Experiment extends AutoPropertyHandler
     public $params;
     public $group;
     public $name;
+
+    /**
+     * @return Param[]
+     */
+    public function getParams()
+    {
+        if ($this->params !== null) {
+            return $this->params;
+        } elseif (isset($this->_jsonData->params)) {
+            if (is_array($this->_jsonData->params)) {
+                $this->params = [];
+                foreach ($this->_jsonData->params as $idx => $value) {
+                    $this->params[$idx] = new Param($value);
+                }
+            } else {
+                $this->params = null;
+            }
+
+            return $this->params;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param Param[] $value
+     *
+     * @return static
+     */
+    public function setParams(
+        array $value)
+    {
+        $this->params = $value;
+        $this->_jsonData->params = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isParams()
+    {
+        return isset($this->_jsonData->params) && $this->_jsonData->params;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getGroup()
+    {
+        if ($this->group !== null) {
+            return $this->group;
+        } elseif (isset($this->_jsonData->group)) {
+            $this->group = $this->_jsonData->group;
+
+            return $this->group;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function setGroup(
+        $value)
+    {
+        $this->group = $value;
+        $this->_jsonData->group = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGroup()
+    {
+        return isset($this->_jsonData->group) && $this->_jsonData->group;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        if ($this->name !== null) {
+            return $this->name;
+        } elseif (isset($this->_jsonData->name)) {
+            $this->name = $this->_jsonData->name;
+
+            return $this->name;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function setName(
+        $value)
+    {
+        $this->name = $value;
+        $this->_jsonData->name = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isName()
+    {
+        return isset($this->_jsonData->name) && $this->_jsonData->name;
+    }
 }

--- a/src/Response/SyncResponse.php
+++ b/src/Response/SyncResponse.php
@@ -6,11 +6,6 @@ use InstagramAPI\AutoPropertyHandler;
 use InstagramAPI\ResponseInterface;
 use InstagramAPI\ResponseTrait;
 
-/**
- * @method Model\Experiment[] getExperiments()
- * @method bool isExperiments()
- * @method setExperiments(Model\Experiment[] $value)
- */
 class SyncResponse extends AutoPropertyHandler implements ResponseInterface
 {
     use ResponseTrait;
@@ -19,4 +14,49 @@ class SyncResponse extends AutoPropertyHandler implements ResponseInterface
      * @var Model\Experiment[]
      */
     public $experiments;
+
+    /**
+     * @return Model\Experiment[]
+     */
+    public function getExperiments()
+    {
+        if ($this->experiments !== null) {
+            return $this->experiments;
+        } elseif (isset($this->_jsonData->experiments)) {
+            if (is_array($this->_jsonData->experiments)) {
+                $this->experiments = [];
+                foreach ($this->_jsonData->experiments as $idx => $value) {
+                    $this->experiments[$idx] = new Model\Experiment($value);
+                }
+            } else {
+                $this->experiments = null;
+            }
+
+            return $this->experiments;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param Model\Experiment[] $value
+     *
+     * @return static
+     */
+    public function setExperiments(
+        array $value)
+    {
+        $this->experiments = $value;
+        $this->_jsonData->experiments = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isExperiments()
+    {
+        return isset($this->_jsonData->experiments) && $this->_jsonData->experiments;
+    }
 }

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -13,15 +13,15 @@ use Psr\Http\Message\ResponseInterface as HttpResponseInterface;
  */
 trait ResponseTrait
 {
-    /** @var string */
+    /** @var string @internal */
     public $status;
-    /** @var string */
+    /** @var string @internal */
     public $message;
-    /** @var \InstagramAPI\Response\Model\_Message[] */
+    /** @var \InstagramAPI\Response\Model\_Message[] @internal */
     public $_messages; // NOTE: Full classpath is needed above for JSONMapper!
-    /** @var mixed */
+    /** @var mixed @internal */
     public $fullResponse;
-    /** @var HttpResponseInterface */
+    /** @var HttpResponseInterface @internal */
     public $httpResponse;
 
     /**
@@ -31,7 +31,7 @@ trait ResponseTrait
      */
     public function isOk()
     {
-        return $this->status === 'ok'; // Can be: 'ok', 'fail'
+        return $this->getStatus() === 'ok'; // Can be: 'ok', 'fail'
     }
 
     /**
@@ -52,7 +52,7 @@ trait ResponseTrait
      */
     public function getStatus()
     {
-        return $this->status;
+        return isset($this->_jsonData->status) ? $this->_jsonData->status : $this->status;
     }
 
     /**


### PR DESCRIPTION
@SteveJobzniak Hi, I want to hear your opinion on this. 

I ported a generator from one of my projects, so there was not so much work on this (in case of rejection). I don't like JsonMapper, because it lacks lazy loading, also it has to process reflection data at least once (or every time, if you run queues to send requests).

Basically this PR replaces JsonMapper with auto-generated setters and getters. I included a couple of samples for generated code. It certainly could be simplified, for example we could skip caching for scalar values.

Also it has a big BC: we must declare all properties protected (or even private), because there must be only one method for obtaining or setting a data.