### PR TITLE
Client, Debug, & Request: Debugger improvements 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -36,7 +36,7 @@ INSERT YOUR CODE HERE
 ``` 
 
 ### Debug Log
-Please post your debug log in the section below; You can enable the debug log by using `new Instagram(true)` instead of `new Instagram()`:
+Please post your debug log in the section below; You can enable the debug log by using `new Instagram(true)` instead of `new Instagram()`. Additionally, you can do `\InstagramAPI\Debug::$debugLog = true;` for the debug log to be saved to a file:
 ```php
 INSERT YOUR DEBUG LOG HERE
 ```

--- a/src/Client.php
+++ b/src/Client.php
@@ -119,6 +119,16 @@ class Client
     private $_resetConnection;
 
     /**
+     * The most recent request processed.
+     *
+     * Used for debugging failed requests in exceptions without needing to
+     * enable debug mode.
+     *
+     * @var Request
+     */
+    private $_lastRequest;
+
+    /**
      * Constructor.
      *
      * @param \InstagramAPI\Instagram $parent
@@ -846,5 +856,26 @@ class Client
     public function zeroRating()
     {
         return $this->_zeroRating;
+    }
+
+    /**
+     * Sets the last processed request.
+     *
+     * @param Request $endpoint The last processed request
+     */
+    public function setLastRequest(
+        $endpoint)
+    {
+        $this->_lastRequest = $endpoint;
+    }
+
+    /**
+     * Gets the last processed point.
+     *
+     * @return Request
+     */
+    public function getLastRequest()
+    {
+        return $this->_lastRequest;
     }
 }

--- a/src/Debug.php
+++ b/src/Debug.php
@@ -4,16 +4,28 @@ namespace InstagramAPI;
 
 class Debug
 {
+    /*
+     * If set to true, the debug logs will, in addition to being printed to console, be placed in the file noted below in $debugLogFile
+     */
+    public static $debugLog = false;
+    /*
+     * The file to place debug logs into when $debugLog is true
+     */
+    public static $debugLogFile = 'debug.log';
+
     public static function printRequest(
         $method,
         $endpoint)
     {
         if (PHP_SAPI === 'cli') {
-            $method = Utils::colouredString("{$method}:  ", 'light_blue');
+            $cMethod = Utils::colouredString("{$method}:  ", 'light_blue');
         } else {
-            $method = $method.':  ';
+            $cMethod = $method.':  ';
         }
-        echo $method.$endpoint."\n";
+        echo $cMethod.$endpoint."\n";
+        if (self::$debugLog) {
+            file_put_contents(self::$debugLogFile, $method.':  '.$endpoint."\n", FILE_APPEND | LOCK_EX);
+        }
     }
 
     public static function printUpload(
@@ -25,6 +37,9 @@ class Debug
             $dat = '→ '.$uploadBytes;
         }
         echo $dat."\n";
+        if (self::$debugLog) {
+            file_put_contents(self::$debugLogFile, "→  $uploadBytes\n", FILE_APPEND | LOCK_EX);
+        }
     }
 
     public static function printHttpCode(
@@ -35,6 +50,9 @@ class Debug
             echo Utils::colouredString("← {$httpCode} \t {$bytes}", 'green')."\n";
         } else {
             echo "← {$httpCode} \t {$bytes}\n";
+        }
+        if (self::$debugLog) {
+            file_put_contents(self::$debugLogFile, "← {$httpCode} \t {$bytes}\n", FILE_APPEND | LOCK_EX);
         }
     }
 
@@ -51,6 +69,9 @@ class Debug
             $response = mb_substr($response, 0, 1000, 'utf8').'...';
         }
         echo $res.$response."\n\n";
+        if (self::$debugLog) {
+            file_put_contents(self::$debugLogFile, "RESPONSE: {$response}\n\n", FILE_APPEND | LOCK_EX);
+        }
     }
 
     public static function printPostData(
@@ -63,5 +84,8 @@ class Debug
             $dat = 'DATA: ';
         }
         echo $dat.urldecode(($gzip ? zlib_decode($post) : $post))."\n";
+        if (self::$debugLog) {
+            file_put_contents(self::$debugLogFile, 'DATA: '.urldecode(($gzip ? zlib_decode($post) : $post))."\n", FILE_APPEND | LOCK_EX);
+        }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -825,6 +825,8 @@ class Request
     public function getResponse(
         Response $responseObject)
     {
+        // Set this request as the most recently processed request
+        $this->_parent->client->setLastRequest($this);
         // Check for API response success and put its response in the object.
         $this->_parent->client->mapServerResponse( // Throws.
             $responseObject,

--- a/src/Request.php
+++ b/src/Request.php
@@ -836,4 +836,14 @@ class Request
 
         return $responseObject;
     }
+
+    /**
+     * Returns the endpoint URL (absolute or relative) of this request.
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->_url;
+    }
 }


### PR DESCRIPTION
This pull request adds a few new features to aid with debugging.

### Changes:
* The client class now stores the most recently processed `Request` object.
  * Useful for seeing which request fails in an exception try/catch without having to enable debug mode.
  * Adds a field in `Client` class: `_lastRequest` which can be modified with `Client#setLastRequest()` and fetched with `Client#getLastRequest()`
* Added `Request#getUrl()`
* You can now have debug logs be sent to a file rather than just the console.
  * Can be enabled by setting the `debugLog` static field in the `Debug` class to true.
  * The default file location can be changed from `debug.log` to anything else by changing the `debugLogFile` static field in the `Debug` class