### PR TITLE
Media: Add getCommentInfos() function

### DIFF
--- a/src/Request/Media.php
+++ b/src/Request/Media.php
@@ -421,6 +421,34 @@ class Media extends RequestCollection
     }
 
     /**
+     * Get summary information about comments.
+     *
+     * @param string|string[] $mediaIds One or more media IDs in Instagram's internal format (ie "3482384834_43294"). Can be an array of strings or a single string.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \InstagramAPI\Exception\InstagramException
+     *
+     * @return \InstagramAPI\Response\CommentInfosResponse
+     */
+    public function getCommentInfos(
+        $mediaIds)
+    {
+        if ($mediaIds === null) {
+            throw new \InvalidArgumentException('You can not pass null to mediaIds!');
+        }
+
+        if (is_array($mediaIds)) {
+            $mediaIds = implode(',', $mediaIds);
+        }
+
+        $request = $this->ig->request('media/comment_infos')
+            ->addParam('media_ids', $mediaIds);
+
+        return $request->getResponse(new Response\CommentInfosResponse());
+    }
+
+    /**
      * Get the replies to a specific media comment.
      *
      * You should be sure that the comment actually HAS more replies before

--- a/src/Request/Media.php
+++ b/src/Request/Media.php
@@ -442,10 +442,9 @@ class Media extends RequestCollection
             $mediaIds = implode(',', $mediaIds);
         }
 
-        $request = $this->ig->request('media/comment_infos')
-            ->addParam('media_ids', $mediaIds);
-
-        return $request->getResponse(new Response\CommentInfosResponse());
+        return $this->ig->request('media/comment_infos')
+            ->addParam('media_ids', $mediaIds)
+            ->getResponse(new Response\CommentInfosResponse());
     }
 
     /**

--- a/src/Response/CommentInfosResponse.php
+++ b/src/Response/CommentInfosResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace InstagramAPI\Response;
+
+use InstagramAPI\Response;
+
+/**
+ * CommentInfosResponse.
+ *
+ * @method Model\UnpredictableKeys\MediaUnpredictableContainer getCommentInfos()
+ * @method mixed getMessage()
+ * @method string getStatus()
+ * @method Model\_Message[] get_Messages()
+ * @method bool isCommentInfos()
+ * @method bool isMessage()
+ * @method bool isStatus()
+ * @method bool is_Messages()
+ * @method $this setCommentInfos(Model\UnpredictableKeys\MediaUnpredictableContainer $value)
+ * @method $this setMessage(mixed $value)
+ * @method $this setStatus(string $value)
+ * @method $this set_Messages(Model\_Message[] $value)
+ * @method $this unsetCommentInfos()
+ * @method $this unsetMessage()
+ * @method $this unsetStatus()
+ * @method $this unset_Messages()
+ */
+class CommentInfosResponse extends Response
+{
+    const JSON_PROPERTY_MAP = [
+        'comment_infos'    => 'Model\UnpredictableKeys\MediaUnpredictableContainer',
+    ];
+}


### PR DESCRIPTION
Hello!

I have discovered recently that Instagram uses a separated request to get comments summary.
Added that request to library.

Sorry for abandoned previous pull request. I just don't know how to edit commits and decided to explore that later.